### PR TITLE
fix: # tokenization

### DIFF
--- a/src/word_piece_tokenizer/Trie.py
+++ b/src/word_piece_tokenizer/Trie.py
@@ -24,7 +24,7 @@ class Trie:
 
         while curr_index < len(text) and text[curr_index] in ref:
             ref = ref[text[curr_index]]
-            if ("" in ref and text[curr_index] != "#"):
+            if ("" in ref and (len(text) == 1 or text[curr_index] != "#")):
                 longest_match_end_index = curr_index
                 longest_match_token = ref[""]
             curr_index += 1

--- a/tests/tokenizer_test.py
+++ b/tests/tokenizer_test.py
@@ -89,6 +89,11 @@ class TestTokenizer(unittest.TestCase):
             for s in sentences:
                 lib_res, my_res = self.tokenize_with_both_tokenizer(s)
                 self.assertEqual(lib_res, my_res)
+    
+    def test_hashtags(self):
+        s = "you are #good! ## bye bye"
+        lib_res, my_res = self.tokenize_with_both_tokenizer(s)
+        self.assertEqual(lib_res, my_res)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, `#` was converted to `[UNK]`

```bash
"you are #good! ## bye bye"
['[CLS]', 'you', 'are', '#', 'good', '!', '#', '#', 'bye', 'bye', '[SEP]']
['[CLS]', 'you', 'are', '[UNK]', 'good', '!', '[UNK]', '[UNK]', 'bye', 'bye', '[SEP]']
```

After fix:
```bash
"you are #good! ## bye bye"
[101, 2017, 2024, 1001, 2204, 999, 1001, 1001, 9061, 9061, 102]
[101, 2017, 2024, 1001, 2204, 999, 1001, 1001, 9061, 9061, 102]
```